### PR TITLE
Use CHROME_BIN environment variable to specify path to Chrome/Chromium.

### DIFF
--- a/tests/_utils.js
+++ b/tests/_utils.js
@@ -4,6 +4,10 @@ const child_process = require('child_process');
 
 
 const getExecutablePath = () => {
+  if (process.env.CHROME_BIN) {
+    return process.env.CHROME_BIN;
+  }
+
   let executablePath;
   if (process.platform === 'linux') {
     try {


### PR DESCRIPTION
Using the `CHROME_BIN` environment variable makes it easy to change which Chromium build is in-use for a test run.  It also enables using this repository under Windows, which was previously not supported.