### PR TITLE
Expose the most recent MediaRecorder timecode on the stream object.

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -46,6 +46,7 @@ function START_RECORDING({ index, video, audio, frameSize, audioBitsPerSecond, v
 						window.sendData({
 							id: index,
 							data,
+							timecode: event.timecode
 						});
 					}
 				}

--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -18,6 +18,8 @@ export class Stream extends Readable {
 		super(options);
 	}
 
+	timecode!: number;
+
 	_read() {}
 
 	// @ts-ignore
@@ -110,8 +112,14 @@ export async function launch(
 	browser.videoCaptureExtension = videoCaptureExtension;
 
 	await browser.videoCaptureExtension.exposeFunction("sendData", (opts: any) => {
+		const encoder = browser.encoders?.get(opts.id);
+		if (!encoder) {
+			return;
+		}
+
 		const data = Buffer.from(str2ab(opts.data));
-		browser.encoders?.get(opts.id)?.push(data);
+		encoder.timecode = opts.timecode;
+		encoder.push(data);
 	});
 
 	await browser.videoCaptureExtension.exposeFunction("log", (...opts: any) => {

--- a/tests/index.js
+++ b/tests/index.js
@@ -27,7 +27,18 @@ async function videoRecorder() {
 		video: true,
 	});
 
-	stream.pipe(file);
+	stream.on('readable', () => {
+		let data;
+
+		while ((data = stream.read()) !== null) {
+			console.log({length: data.length, timecode: stream.timecode});
+			file.write(data);
+		}
+	});
+
+	stream.on('end', () => {
+		file.end();
+	});
 
 	setTimeout(async () => {
 		await stream.destroy();


### PR DESCRIPTION
Some usages of the MediaRecorder data require access to the `timecode` that is included with `dataavailable` events.  To avoid an API change, I have added a `timecode` property to the stream class.  This will contain the most recently emitted `timecode` value, and can be used to approximate the current timestamp for data being read from the stream, if the stream is read in realtime.