### PR TITLE
Use allowlisted-extension-id instead whitelisted-extension-id

### DIFF
--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -49,7 +49,7 @@ export async function launch(
 
 	addToArgs("--load-extension=", extensionPath);
 	addToArgs("--disable-extensions-except=", extensionPath);
-	addToArgs("--whitelisted-extension-id=", extensionId);
+	addToArgs("--allowlisted-extension-id=", extensionId);
 	addToArgs("--autoplay-policy=no-user-gesture-required");
 
 	if (opts.defaultViewport?.width && opts.defaultViewport?.height)


### PR DESCRIPTION
Since October 2021, Chrome's `whitelisted-extension-id` option has been deprecated.
It was replaced by `allowlisted-extension-id`.
With the existing key, the latest chromium does not run the Puppeteer with below messages.

```bash
[34622:259:0328/153354.796775:FATAL:chrome_content_browser_client.cc(2903)] "whitelisted-extension-id" switch is deprecated, please use "allowlisted-extension-id" instead
```

ref:
- https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/chrome_content_browser_client.cc;l=737?q=whitelisted-extension-id&sq=&ss=chromium
- https://source.chromium.org/chromium/chromium/src/+/main:extensions/common/switches.cc;l=22?q=whitelisted-extension-id&ss=chromium