### PR TITLE
Solving a race condition

### DIFF
--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -114,6 +114,10 @@ export interface getStreamOptions {
 	bitsPerSecond?: number;
 	frameSize?: number;
 	delay?: number;
+	retry? : {
+		each? : number,
+		times?: number
+	}
 }
 
 async function getExtensionPage(browser: Browser) {
@@ -135,6 +139,7 @@ export async function getStream(page: Page, opts: getStreamOptions) {
 		else if (opts.audio) opts.mimeType = "audio/webm";
 	}
 	if (!opts.frameSize) opts.frameSize = 20;
+	const retryPolicy = Object.assign({}, {each: 20, times: 3}, opts.retry)
 
 	const extension = await getExtensionPage(page.browser());
 	const index = currentIndex++;
@@ -145,6 +150,7 @@ export async function getStream(page: Page, opts: getStreamOptions) {
 	);
 
 	await page.bringToFront();
+	await assertExtensionLoaded(extension, retryPolicy)
 	extension.evaluate(
 		// @ts-ignore
 		(settings) => START_RECORDING(settings),
@@ -152,6 +158,16 @@ export async function getStream(page: Page, opts: getStreamOptions) {
 	);
 
 	return stream;
+}
+
+async function assertExtensionLoaded( ext: Page, opt: getStreamOptions["retry"]){
+	const wait = (ms: number) => new Promise( res => setTimeout( res, ms))
+	for (let currentTick=0; currentTick< opt.times; currentTick++) {
+		// @ts-ignore
+		if(await ext.evaluate(() => typeof START_RECORDING === "function")) return;
+		await wait(Math.pow(opt.each, currentTick));
+	}
+	throw new Error("Could not find START_RECORDING function in the browser context")
 }
 
 class UDPStream extends Readable {


### PR DESCRIPTION
Hey,
I'm currently using puppeteer-stream for one of my projects. While playing around with it, I've come across this particular bug a few times. 

```sh
Error: Evaluation failed: ReferenceError: START_RECORDING is not defined
    at pptr://__puppeteer_evaluation_script__:1:16
```
I'm using this lib both on my own computer and in a headless docker container, and saw that in the container case, the function declared by the extension had no time to register in the page context before being called.

To solve this, I've added a configurable pseudo-retry policy, that simply checks if the START_RECORDING symbol exists before attempting to retrieve the stream.

Keep up the great work !