### PR TITLE
Fix missing export of UDPStream

### DIFF
--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -154,7 +154,7 @@ export async function getStream(page: Page, opts: getStreamOptions) {
 	return stream;
 }
 
-class UDPStream extends Readable {
+export class UDPStream extends Readable {
 	socket: Socket;
 	constructor(port = 55200, public onDestroy: Function) {
 		super({ highWaterMark: 1024 * 1024 * 8 });


### PR DESCRIPTION
User should be able to use UDPStream in typescript:
```
import { UDPStream, getStream }  from 'child_process'  
const stream: UDPStream;  
stream =  getStream(...)  
```