### PR TITLE
update ffmpeg example to pass through audio/video (without re-encoding)

### DIFF
--- a/examples/ffmpeg.js
+++ b/examples/ffmpeg.js
@@ -18,8 +18,8 @@ async function test() {
 	await page.goto("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
 	const stream = await getStream(page, { audio: true, video: true, frameSize: 1000 });
 	console.log("recording");
-	// this will pipe the stream to ffmpeg and convert the webm to mp4 format
-	const ffmpeg = exec(`ffmpeg -y -i - output.mp4`);
+	// this will pipe the stream to ffmpeg and convert the webm to mkv format (which supports vp8/vp9)
+	const ffmpeg = exec(`ffmpeg -y -i - -c copy output.mkv`);
 	ffmpeg.stderr.on("data", (chunk) => {
 		console.log(chunk.toString());
 	});


### PR DESCRIPTION
using `-c copy` reduces cpu overhead to almost nothing, since the audio/video does not have to be decoded or encoded

it means ffmpeg will create an output file with the original codecs, usually vp8/vp9 for video and opus for audio

it's also possible to ask Chrome for h264 using `mimeType: 'video/webm;codecs=H264'`, which could then be passed through into an mp4 file