### PR TITLE
Fix typing of the launch function when using puppeteer library as first argument

### DIFF
--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -21,7 +21,7 @@ type StreamLaunchOptions = LaunchOptions &
 	};
 
 export async function launch(
-	arg1: StreamLaunchOptions & { launch?: Function; [key: string]: any },
+	arg1: StreamLaunchOptions | { launch?: Function; [key: string]: any },
 	opts?: StreamLaunchOptions
 ): Promise<Browser> {
 	//if puppeteer library is not passed as first argument, then first argument is options


### PR DESCRIPTION
Typing is currently incorrect with an `&`. We expect either the puppeteer library **OR** the launch arguments, so we should use `|` 

Right now the "puppeteer-extra" example doesn't compile if we are using typescript. This PR fix this issue.