### PR TITLE
fix: comma separated --window-size value

### DIFF
--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -55,7 +55,7 @@ export async function launch(
 	addToArgs("--autoplay-policy=no-user-gesture-required");
 
 	if (opts.defaultViewport?.width && opts.defaultViewport?.height)
-		opts.args.push(`--window-size=${opts.defaultViewport.width}x${opts.defaultViewport.height}`);
+		opts.args.push(`--window-size=${opts.defaultViewport.width},${opts.defaultViewport.height}`);
 
 	opts.headless = false;
 


### PR DESCRIPTION
I've discovered the browser doesn't start with the same viewport's resolution.

Checking the parameters, I've found a bug in the syntax of `--window-size` arg's value, which should be comma separated.
Ref: https://peter.sh/experiments/chromium-command-line-switches/#window-size