### PR TITLE
Enable parallel recordings

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,4 +1,0 @@
-chrome.tabs.create(
-	{ active: false, url: `chrome-extension://${chrome.runtime.id}/options.html` },
-	(tab) => {}
-);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,9 +3,6 @@
 	"version": "0.1.0",
 	"key": "ackedhmjjinfocdcekpnbdocpmiffaac",
 	"manifest_version": 3,
-	"background": {
-		"service_worker": "background.js"
-	},
 	"sockets": {
 		"tcp": { "connect": ["*"] }
 	},

--- a/extension/options.js
+++ b/extension/options.js
@@ -31,7 +31,7 @@ async function START_RECORDING({
 		})
 	);
 
-	const client = new WebSocket("ws://localhost:55200/?index=" + index, []);
+	const client = new WebSocket(`ws://localhost:${window.location.hash.substring(1)}/?index=${index}`, []);
 
 	await new Promise((resolve) => {
 		if (client.readyState === WebSocket.OPEN) resolve();

--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -24,7 +24,7 @@ let port: number;
 export const wss = (async () => {
 	for (let i = 55200; i <= 65535; i++) {
 		const ws = new WebSocketServer({ port: i });
-		const promise = await Promise.any([
+		const promise = await Promise.race([
 			new Promise((resolve) => {
 				ws.on("error", (e: any) => {
 					resolve(!e.message.includes("EADDRINUSE"));
@@ -34,7 +34,7 @@ export const wss = (async () => {
 				ws.on("listening", () => {
 					resolve(true);
 				});
-			})
+			}),
 		]);
 		if (promise) {
 			port = i;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
 
 		/* Basic Options */
 		// "incremental": true,                   /* Enable incremental compilation */
-		"target": "ES2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+		"target": "ES2021" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
 		"module": "CommonJS" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
 		"lib": ["ES2015", "DOM"] /* Specify library files to be included in the compilation. */,
 		"allowJs": true /* Allow javascript files to be compiled. */,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
 
 		/* Basic Options */
 		// "incremental": true,                   /* Enable incremental compilation */
-		"target": "ES2021" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+		"target": "ES2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
 		"module": "CommonJS" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
 		"lib": ["ES2015", "DOM"] /* Specify library files to be included in the compilation. */,
 		"allowJs": true /* Allow javascript files to be compiled. */,


### PR DESCRIPTION
## Current State
It's not possible to record parallel in different browsers at the same time, because the websocket port ist hardcoded. As mentioned here https://github.com/SamuelScheit/puppeteer-stream/issues/133, https://github.com/SamuelScheit/puppeteer-stream/issues/139 and https://github.com/SamuelScheit/puppeteer-stream/issues/141

## The Fix
The websocket server is created on port 55200, if the port is already in use, it tries opening it on port+1

To communicate the port information to the extension which needs this information for it's websocket client, the options page get's opened by PuppeteerStream with the port information as url hash, instead of opening the options page by the extension itself

## How to test in debugging
1. Create a new node project
2. Install puppeteer-stream: ```npm i puppeteer-stream```
3. Create index.js file and set the content to
```
const { launch, getStream } = require("puppeteer-stream");
const fs = require("fs");

(async () => {
    const browser = await launch({
        executablePath: "C:/Program Files/Google/Chrome/Application/chrome.exe",
    });
    const page = await browser.newPage();
    await page.goto("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
    const stream = await getStream(page, { audio: true, video: true });

    const file = fs.createWriteStream(__dirname + "/" + parseInt(Math.random() * 100) + ".webm");
    stream.pipe(file);

    await new Promise(r => setTimeout(r, 10000));
    await stream.destroy();
    file.close();
    await browser.close();
})();
```
4. Clone this pull request into parent folder
5. Install dependencies ```npm i --save-dev```
6. Run ```npm run build```
7. Replace this files with the according onces in the node_modules/puppeteer-stream folder of the step 1 project
```
dist/PuppeteerStream.js
extension/manifest.json
extension/options.js
```
8. When done everything right, you should have a runnable node project but with the replaced files from this pull request
9. Open two command lines, navigate to step 1 project and execute parallel ```node index.js```
10. Confirm two .webm files has been created