### PR TITLE
Update code example on how to properly close

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ async function test() {
 		await stream.destroy();
 		file.close();
 		console.log("finished");
+
+		await browser.close();
+		(await wss).close();
 	}, 1000 * 10);
 }
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The method `launch(options)` is just a slightly changed puppeteer [launch](https
 ### [Save Stream to File:](/examples/file.js)
 
 ```js
-const { launch, getStream } = require("puppeteer-stream");
+const { launch, getStream, wss } = require("puppeteer-stream");
 const fs = require("fs");
 
 const file = fs.createWriteStream(__dirname + "/test.webm");


### PR DESCRIPTION
Without ```await browser.close()``` and ```(await wss).close()``` the node programs doesn't stop, when finished, because the browser and the websocketserver are still open

So add it to the documentation