### PR TITLE
fix: cannot launch browser because wrong executablePath

### DIFF
--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -74,12 +74,12 @@ export async function launch(
 	}
 
 	if (!opts.extensionPath) {
-		opts.executablePath = path.join(__dirname, "..", "extension");
+		opts.extensionPath = path.join(__dirname, "..", "extension");
 	}
 
-	addToArgs("--load-extension=", opts.executablePath);
-	addToArgs("--disable-extensions-except=", opts.executablePath);
-	addToArgs("--allowlisted-extension-id=", opts.executablePath);
+	addToArgs("--load-extension=", opts.extensionPath);
+	addToArgs("--disable-extensions-except=", opts.extensionPath);
+	addToArgs("--allowlisted-extension-id=", opts.extensionPath);
 	addToArgs("--autoplay-policy=no-user-gesture-required");
 
 	if (opts.defaultViewport?.width && opts.defaultViewport?.height) {


### PR DESCRIPTION
hi @SamuelScheit, the latest code currently cannot launch the browser, and I see that there is confusion between `extensionPath` and `executablePath`. I created this PR to fix that problem, hope you'll check it out.

Thanks.