### PR TITLE
feat: public getExtensionPage

### DIFF
--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -197,7 +197,7 @@ export interface getStreamOptions {
 	};
 }
 
-async function getExtensionPage(browser: Browser) {
+export async function getExtensionPage(browser: Browser) {
 	const extensionTarget = await browser.waitForTarget((target) => {
 		return target.type() === "page" && target.url().startsWith(`chrome-extension://${extensionId}/options.html`);
 	});


### PR DESCRIPTION
Hello.

We use your library to record a puppeteer browser tab.
Recently we started getting the error "DOMException: Error starting tab capture" and would like to add checks in our application.
For this we would not like copy-paste methods, as they may change.

This PR simply makes the function public.