### PR TITLE
Added optional tabQuery parameter to manually query for the correct tab

### DIFF
--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -176,6 +176,29 @@ interface IPuppeteerStreamOpts {
 	port: number;
 }
 
+interface TabQueryOptions {
+	active?: boolean;
+	audible?: boolean;
+	autoDiscardable?: boolean;
+	currentWindow?: boolean;
+	discarded?: boolean;
+	groupId?: number;
+	highlighted?: boolean;
+	index?: number;
+	lastFocusedWindow?: boolean;
+	muted?: boolean;
+	pinned?: boolean;
+	status?: TabStatus;
+	title?: string;
+	url?: string | string[];
+	windowId?: number;
+	windowType?: WindowType;
+}
+
+type TabStatus = "unloaded" | "loading" | "complete";
+
+type WindowType = "normal" | "popup" | "panel" | "app" | "devtools";
+
 export interface getStreamOptions {
 	audio: boolean;
 	video: boolean;
@@ -187,6 +210,11 @@ export interface getStreamOptions {
 	bitsPerSecond?: number;
 	frameSize?: number;
 	delay?: number;
+	/**
+	 * Tab query options to target the correct tab,
+	 * see [Chrome's extensions documentation](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-query) for more info.
+	 */
+	tabQuery?: TabQueryOptions;
 	retry?: {
 		each?: number;
 		times?: number;
@@ -250,13 +278,13 @@ export async function getStream(page: Page, opts: getStreamOptions) {
 			// @ts-ignore
 			return chrome.tabs.query(x);
 		},
-		{
+		opts.tabQuery || {
 			active: true,
 		}
 	);
 
 	unlock();
-	if (!tab) throw new Error("Cannot find tab");
+	if (!tab) throw new Error("Cannot find tab, try providing your own tabQuery to getStream options");
 
 	const stream = new Transform({
 		highWaterMark: 1024 * 1024 * highWaterMarkMB,


### PR DESCRIPTION
I got this error `Cannot find tab` when trying to load a certain web page. For some reason it just couldn't find the correct tab. I've found a way around it by using my own custom query, and this PR exposes the ability to do that.

This is a duplicate of a PR I closed a while ago (#151) which I closed for reasons I cannot even remember, and I can't re-open it for some reason too (when I re-open it just automatically closes). 