### PR TITLE
Fix extension not loaded #204

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The method [`launch(options)`](https://github.com/SamuelScheit/puppeteer-stream/
 	startDelay?: number, // to fix rarely occurring "Error: net::ERR_BLOCKED_BY_CLIENT at chrome-extension://jjndjgheafjngoipoacpjgeicjeomjli/options.html", set and increase number (in ms). Default: 250 ms
 	closeDelay?: number, // to fix rarely occurring TargetCloseError, set and increase number (in ms)
 	extensionPath?: string, // used internally to load the puppeteer-stream browser extension (needed for electron https://github.com/SamuelScheit/puppeteer-stream/issues/137)
+	enableExtensions?: string array, // load additional extensions from disk
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The method [`launch(options)`](https://github.com/SamuelScheit/puppeteer-stream/
 ```ts
 {
 	allowIncognito?: boolean, // to be able to use incognito mode
+	startDelay?: number, // to fix rarely occurring "Error: net::ERR_BLOCKED_BY_CLIENT at chrome-extension://jjndjgheafjngoipoacpjgeicjeomjli/options.html", set and increase number (in ms). Default: 250 ms
 	closeDelay?: number, // to fix rarely occurring TargetCloseError, set and increase number (in ms)
 	extensionPath?: string, // used internally to load the puppeteer-stream browser extension (needed for electron https://github.com/SamuelScheit/puppeteer-stream/issues/137)
 }

--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -14,6 +14,8 @@ let currentIndex = 0;
 type StreamLaunchOptions = LaunchOptions & {
 		allowIncognito?: boolean;
 	} & {
+		startDelay?: number;
+	} & {
 		closeDelay?: number;
 	} & {
 		extensionPath?: string;
@@ -103,6 +105,9 @@ export async function launch(
 	} else {
 		browser = await puppeteerLaunch(opts);
 	}
+
+	// Delay to let Chrome load the extension
+	await new Promise((r) => setTimeout(r, opts.startDelay || 250));
 
 	if (opts.allowIncognito) {
 		const settings = await browser.newPage();


### PR DESCRIPTION
When starting I get
```Error: net::ERR_BLOCKED_BY_CLIENT at chrome-extension://jjndjgheafjngoipoacpjgeicjeomjli/options.html#55200```
https://github.com/samuelscheit/puppeteer-stream/issues/204

**The Issue**
Extension is not yet loaded by Chrome

**The Fix**
Add default delay of 250 ms which fixes the issue for most of the users.
For users with slow disk speed, they can set startDelay option in the launch arguments to customize the delay